### PR TITLE
Add delay to submenu disappearance

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/components/ContextMenu.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/ContextMenu.vue
@@ -13,8 +13,8 @@
                 v-else
                 :key="index"
                 :class="{ 'item': true, 'submenu': !!item.submenu }"
-                @mouseenter="activeMenu = index"
-                @mouseleave="activeMenu = -1"
+                @mouseenter="onMouseEnter($event, index)"
+                @mouseleave="onMouseLeave($event, index)"
                 @click.stop.prevent="onClick(item)"
                 class="d-flex align-items-center"
             >
@@ -54,6 +54,7 @@ export interface IMenuItem {
 export default class ContextMenu extends Vue {
 
     activeMenu = -1;
+    activeMenuResetTimeout: number|null = null;
 
     @Prop({ type: Boolean, default: false })
     value!: boolean;
@@ -101,6 +102,26 @@ export default class ContextMenu extends Vue {
     onClickOutside(event: MouseEvent) {
         if (this.value) {
             this.$emit("input", false);
+        }
+    }
+
+    onMouseEnter(event: MouseEvent, index: number) {
+        if (this.items[index].submenu) {
+            this.activeMenu = index;
+
+            if (this.activeMenuResetTimeout !== null) {
+                clearTimeout(this.activeMenuResetTimeout);
+                this.activeMenuResetTimeout = null;
+            }
+        }
+    }
+
+    onMouseLeave(event: MouseEvent, index: number) {
+        if (this.items[index].submenu) {
+            this.activeMenuResetTimeout = window.setTimeout(() => {
+                this.activeMenu = -1;
+                this.activeMenuResetTimeout = null;
+            }, 200);
         }
     }
 

--- a/packages/baklavajs-plugin-renderer-vue/src/styles/dark/context-menu.scss
+++ b/packages/baklavajs-plugin-renderer-vue/src/styles/dark/context-menu.scss
@@ -3,8 +3,8 @@
     position: absolute;
     display: inline-block;
     z-index: 100;
-    background-color: #000000AA;
-    filter: drop-shadow(0 0 4px black);
+    background-color: #000000CC;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.65);
     border-radius: 0 0 $border-radius-control $border-radius-control;
     min-width: 100px;
 


### PR DESCRIPTION
Delays the disappearance of submenus in context menus by 200ms, allowing the user to move their cursor to the submenu even if they accidentally hover over other menu items, as long as those don't open another submenu.

Includes a style change to fix repaint not triggering correctly in Firefox when using `filter: drop-shadow()`. I made it visually similar to the original. This PR also makes `activeMenu` only be set when the hovered menu item has a submenu, leaving it at `-1` otherwise.