### PR TITLE
Add setName to NodeBuilder

### DIFF
--- a/docs/custom-nodes.md
+++ b/docs/custom-nodes.md
@@ -37,6 +37,7 @@ The [NodeBuilder](!!API%{ "module": "@baklavajs/core", "type": "class", "name": 
 import { NodeBuilder } from "baklavajs";
 
 export default new NodeBuilder("MathNode")
+    .setName("Math")
     .addInputInterface("Number 1", "NumberOption", 1)
     .addInputInterface("Number 2", "NumberOption", 10)
     .addOption("Operation", "SelectOption", () => ({
@@ -68,9 +69,9 @@ and implement the required methods/properties yourself.
 import { Node, Options } from "baklavajs";
 
 export class MathNode extends Node {
-    
+
     type = "MathNode";
-    name = this.type;
+    name = "Math";
 
     constructor() {
         super();

--- a/packages/baklavajs-core/src/node.ts
+++ b/packages/baklavajs-core/src/node.ts
@@ -19,7 +19,7 @@ export abstract class Node {
 
     /** Type of the node */
     public abstract type: string;
-    /** Name of the node. Should be set equal to [[type]] by default */
+    /** Customizable display name of the node. */
     public abstract name: string;
     /** Unique identifier of the node */
     public id: string = "node_" + generateId();

--- a/packages/baklavajs-core/src/nodeBuilder.ts
+++ b/packages/baklavajs-core/src/nodeBuilder.ts
@@ -19,13 +19,13 @@ function getDefaultValue(v: any) {
 }
 
 function generateNode(
-    type: string, intfs: IInterfaceOptions[],
+    type: string, name: string, intfs: IInterfaceOptions[],
     options: Map<string, IOption>, calcFunction?: CalculationFunction
 ) {
     return class extends Node {
 
         type = type;
-        name = type;
+        name = name;
 
         constructor() {
             super();
@@ -53,13 +53,15 @@ function generateNode(
 /** Utility class for creating custom nodes */
 export class NodeBuilder {
 
+    private type = "";
     private name = "";
     private intfs: IInterfaceOptions[] = [];
     private options: Map<string, IOption> = new Map();
     private calcFunction?: CalculationFunction;
 
-    public constructor(name: string) {
-        this.name = name;
+    public constructor(type: string) {
+        this.type = type;
+        this.name = type;
     }
 
     /**
@@ -68,7 +70,17 @@ export class NodeBuilder {
      * @returns The generated node class
      */
     public build(): NodeConstructor {
-        return generateNode(this.name, this.intfs, this.options, this.calcFunction) as NodeConstructor;
+        return generateNode(this.type, this.name, this.intfs, this.options, this.calcFunction) as NodeConstructor;
+    }
+
+    /**
+     * Set a display name for the node.
+     * @param name New name of the node
+     * @returns Current node builder instance for chaining
+     */
+    public setName(name: string): NodeBuilder {
+        this.name = name;
+        return this;
     }
 
     /**


### PR DESCRIPTION
Adds a method to the `NodeBuilder` to allow setting the default display name of a node.

Closes #16 