### PR TITLE
Node.addNode() now works outside of the contructor (#89)

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
@@ -43,7 +43,7 @@
 
             <!-- Options -->
             <div class="__options">
-                <template v-for="[name, option] in options">
+                <template v-for="[name, option] in data.options">
 
                     <component
                         :is="plugin.components.nodeOption"


### PR DESCRIPTION
Previously the Node.addNode only worked when it was called in the constructor of the class. Now it always works.

See Issue #89 