### PR TITLE
Feature: Moving background

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
@@ -9,6 +9,8 @@
         @keyup="keyUp"
         @contextmenu.self.prevent="openContextMenu"
     >
+        <div class="background" :style="backgroundStyle">
+        </div>
 
         <svg class="connections-container">
             <g v-for="connection in connections" :key="connection.id + counter.toString()">
@@ -100,10 +102,26 @@ export default class EditorView extends Vue {
         y: 0
     };
 
+    backgrounGrid = {
+        gridSize: 100,
+        gridDivision: 5,
+        subGridVisibleThreshold: 0.6,
+    };
+
     get styles() {
         return {
             "transform-origin": "0 0",
             "transform": `scale(${this.plugin.scaling}) translate(${this.plugin.panning.x}px, ${this.plugin.panning.y}px)`
+        };
+    }
+
+    get backgroundStyle() {
+        const size = this.plugin.scaling * this.backgrounGrid.gridSize;
+        const subSize = size / this.backgrounGrid.gridDivision;
+        return {
+            "background-position": `left ${this.plugin.panning.x * this.plugin.scaling}px top ${this.plugin.panning.y * this.plugin.scaling}px`,
+            "background-size": `${size}px ${size}px, ${size}px ${size}px`
+                + (this.plugin.scaling > this.backgrounGrid.subGridVisibleThreshold ? `, ${subSize}px ${subSize}px, ${subSize}px ${subSize}px` : '')
         };
     }
 

--- a/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/backgroundpattern.scss
+++ b/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/backgroundpattern.scss
@@ -8,6 +8,4 @@ $color-pattern-black: #00000022;
         linear-gradient(90deg, $color-pattern-black 2px, transparent 2px),
         linear-gradient($color-pattern-line 1px, transparent 1px),
         linear-gradient(90deg, $color-pattern-line 1px, transparent 1px);
-    background-size: 100px 100px, 100px 100px, 20px 20px, 20px 20px;
-    background-position:-2px -2px, -2px -2px, -1px -1px, -1px -1px;
 }

--- a/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/node-editor.scss
+++ b/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/node-editor.scss
@@ -52,6 +52,9 @@
 }
 
 .node-container {
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     pointer-events: none;

--- a/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/node-editor.scss
+++ b/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/node-editor.scss
@@ -13,7 +13,13 @@
     outline: none !important;
     font-family: 'Lato', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     font-size: 13px;
-    @include backgroundpattern();
+
+    .background {
+        @include backgroundpattern();
+        width: 100%;
+        height: 100%;
+        pointer-events: none !important;
+    }
 
     & *:not(input):not(textarea) {
         user-select: none;


### PR DESCRIPTION
Background is now interactively moving, this give more depth to the graph and allow a better experience.

Grid size settings can be changed with the `backgroundGrid` attribute of the `EditorView` class.
The number of cell for the sub grid can be tweaked via the `backgrounGrid.gridDivision` attribute.

When zooming out, the sub grid disappears for more visibility. This setting can be change through the `backgrounGrid.subGridVisibleThreshold`.

![moving-grid](https://user-images.githubusercontent.com/31007874/99423981-6fa93b80-2901-11eb-9644-c028949f0263.gif)
