### PR TITLE
Changed node title cursor

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/node.scss
+++ b/packages/baklavajs-plugin-renderer-vue/src/styles/node-editor/node.scss
@@ -20,7 +20,7 @@
         filter: drop-shadow(0 0 7px #000000cc);
 
         & > .__title {
-            cursor: move;
+            cursor: grabbing;
         }
     }
 
@@ -29,6 +29,7 @@
         color: $color-node-title-foreground;
         padding: 0.4em 0.75em;
         border-radius: $border-radius-node $border-radius-node 0 0;
+        cursor: grab;
 
         & > span {
             pointer-events: none;


### PR DESCRIPTION
Hello,

in my opinion the current cursor for the title of the node is not the best option. In my opinion the grab and the grabbing cursor are more suitable. The move cursor is indeed used to move elements (see [MDN cursor](https://developer.mozilla.org/de/docs/Web/CSS/cursor)) 
But this source also says that grab/grabbing "Indicates that something can be grabbed (dragged to be moved)."
The move cursor is fine by itself but I think the combination out of grab and grabbing is better because if you start dragging you will see the change between draggable and dragging better.

Let me know if you are the same opinion or if I am missing something.

Example:
![KVnHxQGuRe](https://user-images.githubusercontent.com/24526399/109147296-23259580-7765-11eb-8553-4e332fc36678.gif)



