### PR TITLE
Add support for custom classes per node

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
@@ -134,6 +134,7 @@ export default class NodeView extends Vue {
             "--dragging": !!this.draggingStartPoint,
             "--two-column": !!this.data.twoColumn,
             [`--type-${sanitizeName(this.data.type)}`]: true,
+            [this.data.customClasses]: true,
         };
     }
 

--- a/packages/baklavajs-plugin-renderer-vue/src/viewPlugin.ts
+++ b/packages/baklavajs-plugin-renderer-vue/src/viewPlugin.ts
@@ -80,10 +80,12 @@ export class ViewPlugin implements IPlugin, IViewPlugin {
             n.disablePointerEvents = false;
             n.twoColumn = n.twoColumn || false;
             n.width = n.width || 200;
+            n.customClasses = n.customClasses || "";
             node.hooks.save.tap(this, (state) => {
                 state.position = n.position;
                 state.width = n.width;
                 state.twoColumn = n.twoColumn;
+                state.customClasses = n.customClasses;
                 return state;
             });
             node.hooks.load.tap(this, (state) => {

--- a/packages/baklavajs-plugin-renderer-vue/types/viewPlugin.ts
+++ b/packages/baklavajs-plugin-renderer-vue/types/viewPlugin.ts
@@ -6,6 +6,7 @@ export interface IViewNode extends INode {
     width: number;
     disablePointerEvents: boolean;
     twoColumn: boolean;
+    customClasses: string;
 }
 
 export interface IViewPlugin extends IPlugin {


### PR DESCRIPTION
This feature allows you to set customer classes per node type. I'm using this to style certain types of nodes belonging to different categories

Ex, using `NodeBuilder`:
```javascript
export default new NodeBuilder("BuilderTestNode", { twoColumn: true, width: 400, customClasses: "very-special-class" })
...
```

![](https://i.imgur.com/4WebM13.png)

Let me know if there are any concerns with this feature or approach, cheers!