### PR TITLE
Add support for multi-node moving

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
@@ -77,6 +77,8 @@ import { IMenuItem } from "./ContextMenu.vue";
 import Clipboard from "../clipboard";
 import History from "../history";
 
+import NodeView from "./node/Node.vue";
+
 interface IPosition {
     x: number;
     y: number;
@@ -90,6 +92,9 @@ export default class EditorView extends Vue {
 
     @Provide("editor")
     nodeeditor: EditorView = this;
+
+    @Provide("selectedNodeViews")
+    selectedNodeViews: NodeView[] = [];
 
     clipboard!: Clipboard;
     history!: History;
@@ -161,7 +166,6 @@ export default class EditorView extends Vue {
         });
         this.clipboard = new Clipboard(this.plugin.editor);
         this.history = new History(this.plugin);
-        Vue.prototype.$selectedNodeEvents = [];
     }
 
     @Watch("plugin.nodeTypeAliases")
@@ -326,18 +330,18 @@ export default class EditorView extends Vue {
         }
     }
 
-    selectNode(node: IViewNode, event: Event) {
+    selectNode(node: IViewNode, event: NodeView) {
         if (!this.ctrlPressed) {
             this.unselectAllNodes();
         }
 
         this.selectedNodes.push(node);
-        Vue.prototype.$selectedNodeEvents.push(event);
+        this.selectedNodeViews.push(event);
     }
 
     unselectAllNodes() {
         this.selectedNodes.splice(0, this.selectedNodes.length);
-        Vue.prototype.$selectedNodeEvents.splice(0, Vue.prototype.$selectedNodeEvents.length);
+        this.selectedNodeViews.splice(0, this.selectedNodeViews.length);
     }
 
     openContextMenu(event: MouseEvent) {

--- a/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
@@ -330,13 +330,13 @@ export default class EditorView extends Vue {
         }
     }
 
-    selectNode(node: IViewNode, event: NodeView) {
+    selectNode(node: IViewNode, nodeView: NodeView) {
         if (!this.ctrlPressed) {
             this.unselectAllNodes();
         }
 
         this.selectedNodes.push(node);
-        this.selectedNodeViews.push(event);
+        this.selectedNodeViews.push(nodeView);
     }
 
     unselectAllNodes() {

--- a/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
@@ -35,7 +35,7 @@
                 :key="node.id + counter.toString()"
                 :data="node"
                 :selected="selectedNodes.includes(node)"
-                @select="selectNode(node)"
+                @select="selectNode(node, $event)"
             >
             </component>
         </div>
@@ -161,6 +161,7 @@ export default class EditorView extends Vue {
         });
         this.clipboard = new Clipboard(this.plugin.editor);
         this.history = new History(this.plugin);
+        Vue.prototype.$selectedNodeEvents = [];
     }
 
     @Watch("plugin.nodeTypeAliases")
@@ -325,15 +326,18 @@ export default class EditorView extends Vue {
         }
     }
 
-    selectNode(node: IViewNode) {
+    selectNode(node: IViewNode, event: Event) {
         if (!this.ctrlPressed) {
             this.unselectAllNodes();
         }
+
         this.selectedNodes.push(node);
+        Vue.prototype.$selectedNodeEvents.push(event);
     }
 
     unselectAllNodes() {
         this.selectedNodes.splice(0, this.selectedNodes.length);
+        Vue.prototype.$selectedNodeEvents.splice(0, Vue.prototype.$selectedNodeEvents.length);
     }
 
     openContextMenu(event: MouseEvent) {

--- a/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
@@ -112,6 +112,9 @@ export default class NodeView extends Vue {
     @Inject("plugin")
     plugin!: ViewPlugin;
 
+    @Inject("selectedNodeViews")
+    selectedNodeViews!: NodeView[];
+
     draggingStartPosition: IPosition | null = null;
     draggingStartPoint: IPosition | null = null;
     renaming = false;
@@ -171,11 +174,12 @@ export default class NodeView extends Vue {
     startDrag(ev: MouseEvent) {
         this.select();
 
-        if (Vue.prototype.$selectedNodeEvents.length === 0 || Vue.prototype.$selectedNodeEvents[0] === undefined) {
-            Vue.prototype.$selectedNodeEvents = [this];
+        if (this.selectedNodeViews.length === 0 || this.selectedNodeViews[0] === undefined) {
+            this.selectedNodeViews.splice(0, this.selectedNodeViews.length);
+            this.selectedNodeViews.push(this);
         }
 
-        Vue.prototype.$selectedNodeEvents.forEach((elem: any) => {
+        this.selectedNodeViews.forEach((elem: any) => {
             elem.draggingStartPoint = {
                   x: ev.screenX,
                   y: ev.screenY,
@@ -194,7 +198,7 @@ export default class NodeView extends Vue {
     }
 
     stopDrag() {
-        Vue.prototype.$selectedNodeEvents.forEach((elem: any) => {
+        this.selectedNodeViews.forEach((elem: any) => {
             elem.draggingStartPoint = null;
             elem.draggingStartPosition = null;
             document.removeEventListener("mousemove", elem.handleMove);
@@ -203,7 +207,7 @@ export default class NodeView extends Vue {
     }
 
     handleMove(ev: MouseEvent) {
-        Vue.prototype.$selectedNodeEvents.forEach((elem: any) => {
+        this.selectedNodeViews.forEach((elem: any) => {
             if (elem.draggingStartPoint) {
                 const dx = ev.screenX - elem.draggingStartPoint.x;
                 const dy = ev.screenY - elem.draggingStartPoint.y;

--- a/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/node/Node.vue
@@ -169,17 +169,24 @@ export default class NodeView extends Vue {
     }
 
     startDrag(ev: MouseEvent) {
-        this.draggingStartPoint = {
-            x: ev.screenX,
-            y: ev.screenY,
-        };
-        this.draggingStartPosition = {
-            x: this.data.position.x,
-            y: this.data.position.y,
-        };
-        document.addEventListener("mousemove", this.handleMove);
-        document.addEventListener("mouseup", this.stopDrag);
         this.select();
+
+        if (Vue.prototype.$selectedNodeEvents.length === 0 || Vue.prototype.$selectedNodeEvents[0] === undefined) {
+            Vue.prototype.$selectedNodeEvents = [this];
+        }
+
+        Vue.prototype.$selectedNodeEvents.forEach((elem: any) => {
+            elem.draggingStartPoint = {
+                  x: ev.screenX,
+                  y: ev.screenY,
+            };
+            elem.draggingStartPosition = {
+                  x: elem.data.position.x,
+                  y: elem.data.position.y,
+            };
+            document.addEventListener("mousemove", elem.handleMove);
+            document.addEventListener("mouseup", elem.stopDrag);
+        });
     }
 
     select() {
@@ -187,19 +194,23 @@ export default class NodeView extends Vue {
     }
 
     stopDrag() {
-        this.draggingStartPoint = null;
-        this.draggingStartPosition = null;
-        document.removeEventListener("mousemove", this.handleMove);
-        document.removeEventListener("mouseup", this.stopDrag);
+        Vue.prototype.$selectedNodeEvents.forEach((elem: any) => {
+            elem.draggingStartPoint = null;
+            elem.draggingStartPosition = null;
+            document.removeEventListener("mousemove", elem.handleMove);
+            document.removeEventListener("mouseup", elem.stopDrag);
+        });
     }
 
     handleMove(ev: MouseEvent) {
-        if (this.draggingStartPoint) {
-            const dx = ev.screenX - this.draggingStartPoint.x;
-            const dy = ev.screenY - this.draggingStartPoint.y;
-            this.data.position.x = this.draggingStartPosition!.x + dx / this.plugin.scaling;
-            this.data.position.y = this.draggingStartPosition!.y + dy / this.plugin.scaling;
-        }
+        Vue.prototype.$selectedNodeEvents.forEach((elem: any) => {
+            if (elem.draggingStartPoint) {
+                const dx = ev.screenX - elem.draggingStartPoint.x;
+                const dy = ev.screenY - elem.draggingStartPoint.y;
+                elem.data.position.x = elem.draggingStartPosition.x + dx / elem.plugin.scaling;
+                elem.data.position.y = elem.draggingStartPosition.y + dy / elem.plugin.scaling;
+            }
+        });
     }
 
     openContextMenu(ev: MouseEvent) {


### PR DESCRIPTION
This feature adds support for allowing multiple nodes that have been selected with CTRL to be moved at the same time while CTRL is held

![](https://i.imgur.com/pyQ3rNP.gif)

Sitenote: I used the `Vue` object to store which nodes we're selecting, which 100% is not ideal - but I'm not sure how else we can optimally pass this data context between the two templates. Please let me know how I can improve this, as I think its a pretty solid feature to have!

Cheers!