### PR TITLE
Add missing minimap export, correct class names

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/index.ts
+++ b/packages/baklavajs-plugin-renderer-vue/src/index.ts
@@ -3,16 +3,17 @@ export { default as Editor } from "./components/Editor.vue";
 import Connection from "./components/connection/ConnectionView.vue";
 import ConnectionWrapper from "./components/connection/ConnectionWrapper.vue";
 import TemporaryConnection from "./components/connection/TemporaryConnection.vue";
-import Node from "./components/node/Node.vue";
-import NodeInterface from "./components/node/NodeInterface.vue";
-import NodeOption from "./components/node/NodeOption.vue";
+import NodeView from "./components/node/Node.vue";
+import NodeInterfaceView from "./components/node/NodeInterface.vue";
+import NodeOptionView from "./components/node/NodeOption.vue";
 import ContextMenu from "./components/ContextMenu.vue";
 import Sidebar from "./components/Sidebar.vue";
+import Minimap from "./components/Minimap.vue";
 
 export const Components = {
     Connection, ConnectionWrapper, TemporaryConnection,
-    Node, NodeInterface, NodeOption,
-    ContextMenu, Sidebar
+    NodeView, NodeInterfaceView, NodeOptionView,
+    ContextMenu, Sidebar, Minimap
 };
 
 export * from "./baklavaVuePlugin";


### PR DESCRIPTION
Minimap was missing in Vue-Renderer Components export
Node, NodeInterface, NodeOption were exported with incorrect class names