### PR TITLE
Show text of selected non-truthy items

### DIFF
--- a/packages/baklavajs-plugin-options-vue/src/SelectOption.vue
+++ b/packages/baklavajs-plugin-options-vue/src/SelectOption.vue
@@ -65,10 +65,10 @@ export default class SelectOption extends Vue {
     }
 
     get selectedText() {
-        if (this.value) {
-            return this.isAdvancedMode ?
-                this.getItemByValue(this.value)?.text ?? "" :
-                this.value;
+        if (this.isAdvancedMode) {
+            return this.getItemByValue(this.value)?.text ?? "";
+        } else if(this.value) {
+            return this.value;
         } else {
             return "";
         }


### PR DESCRIPTION
Hi, thanks a lot for this project!

When adding a SelectOption Interface with an item whose value is non-truthy (for example 0), this option's text should be shown when it is selected.

An example that I would like to use is this:
```js
    node.addInputInterface('Input', 'SelectOption', undefined, {
        items: [{ text: "on", value: 1}, { text: "off", value: 0 }]
    });
```
Currently, when selecting "off", the `this.value` is 0, which is not truthy, so "" is shown as the selected value instead of "off".

With my change, we always try to get the corresponding text from the items list. If `value` is set to an option that is not in
the list of options, `getItemByValue` will return undefined, which will be converted to an empty string, as it was before.