### PR TITLE
Fix unresolved reference to baklavajs-core types

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
+++ b/packages/baklavajs-plugin-renderer-vue/src/components/Editor.vue
@@ -69,6 +69,8 @@ import {
     INodeInterface,
     ITemporaryConnection,
     TemporaryConnectionState,
+    INode,
+    IConnection,
 } from "../../../baklavajs-core/types";
 import { ViewPlugin } from "../viewPlugin";
 import { IViewNode } from "../../types";
@@ -142,11 +144,11 @@ export default class EditorView extends Vue {
         };
     }
 
-    get nodes() {
+    get nodes(): readonly INode[] {
         return this.plugin.editor ? this.plugin.editor.nodes : [];
     }
 
-    get connections() {
+    get connections(): readonly IConnection[] {
         return this.plugin.editor ? this.plugin.editor.connections : [];
     }
 


### PR DESCRIPTION
Hello,

Thanks a lot for building this!

After upgrading typescript to 4.7 and disabling the `"skipLibCheck": true` setting in the tsconfig.json of one of my projects, I was greeted with the following complaint by typescript:
```
Error: node_modules/@baklavajs/plugin-renderer-vue/dist/baklavajs-plugin-renderer-vue/src/components/Editor.vue.d.ts:42:34 - error TS2307: Cannot find module 'packages/baklavajs-core/types/node' or its corresponding type declarations.

42     get nodes(): readonly import("packages/baklavajs-core/types/node").INode[];
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Error: node_modules/@baklavajs/plugin-renderer-vue/dist/baklavajs-plugin-renderer-vue/src/components/Editor.vue.d.ts:43:40 - error TS2307: Cannot find module 'packages/baklavajs-core/types/connection' or its corresponding type declarations.

43     get connections(): readonly import("packages/baklavajs-core/types/connection").IConnection[];
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I don't fully understand how the Editor.vue.d.ts file is generated during the build process, but I could find a way to satisfy the compiler by explicitly setting the return type of the getters in question, and importing them relatively, as is done with the other types from the baklavajs-core/types folder.

Running the build command on my system now produces a version of the library that the compiler is happy with.