### PR TITLE
Fix missing export for scss

### DIFF
--- a/packages/baklavajs-plugin-renderer-vue/package.json
+++ b/packages/baklavajs-plugin-renderer-vue/package.json
@@ -15,7 +15,9 @@
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
-    "./dist/styles.css": "./dist/styles.css"
+    "./dist/styles.css": "./dist/styles.css",
+    "./dist/styles/variables.scss": "./dist/styles/variables.scss",
+    "./dist/styles/styles.scss": "./dist/styles/styles.scss"
   },
   "types": "dist/baklavajs-plugin-renderer-vue/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
In the styling section of the documentation, we are instructed to override values by creating an scss file like this and import it. https://newcat.github.io/baklavajs/#/styling
```
@import "@baklavajs/plugin-renderer-vue/dist/styles/variables.scss";

// change variables here

@import "@baklavajs/plugin-renderer-vue/dist/styles/styles.scss";
```
However, without specifying the file to be exported in package.json, the files cannot be used and will crash the bundler saying ```Error: Missing "./dist/styles/variables.scss" export in "@baklavajs/plugin-renderer-vue" package```

This PR simply adds back the required exports to `package.json`