### PR TITLE
Fix load failure of NodeInterface

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -123,14 +123,15 @@ export abstract class AbstractNode implements IBaklavaEventEmitter, IBaklavaTapa
         Object.entries(state.inputs).forEach(([k, v]) => {
             if (this.inputs[k]) {
                 this.inputs[k].load(v);
+                this.inputs[k].nodeId = this.id;
             }
         });
         Object.entries(state.outputs).forEach(([k, v]) => {
             if (this.outputs[k]) {
                 this.outputs[k].load(v);
+                this.outputs[k].nodeId = this.id;
             }
         });
-        this.initializeIo();
         this.events.loaded.emit(this as any);
     }
 

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -130,6 +130,7 @@ export abstract class AbstractNode implements IBaklavaEventEmitter, IBaklavaTapa
                 this.outputs[k].load(v);
             }
         });
+        this.initializeIo();
         this.events.loaded.emit(this as any);
     }
 


### PR DESCRIPTION
#224
This PR fixes a problem where connections were not repainted when nodes moved after loading a saved graph.

This occurs because the ID of the node set in the following description is inconsistent with the ID of the node after loading.
https://github.com/newcat/baklavajs/blob/662639e2c95cff82a26c86ba0c540120b8fe7310/packages/core/src/node.ts#L169
