### PR TITLE
Add user-select webkit vendor prefix to v2

### DIFF
--- a/packages/themes/src/classic/components/node-editor.scss
+++ b/packages/themes/src/classic/components/node-editor.scss
@@ -23,12 +23,14 @@
     & *:not(input):not(textarea) {
         user-select: none;
         -moz-user-select: none;
+        -webkit-user-select: none;
         touch-action: none;
     }
 
     .input-user-select {
         user-select: auto;
         -moz-user-select: auto;
+        -webkit-user-select: auto;
     }
 
     & *,


### PR DESCRIPTION
Cool library. Currently when creating connections in Safari, the following happens:

<img width="579" alt="Screenshot 2023-02-07 at 7 18 27 AM" src="https://user-images.githubusercontent.com/431691/217255858-e7402884-2acb-4a59-a9c1-5208308c7293.png">

This is because `user-select` requires a vendor prefix for safari and ios safari ([mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select#browser_compatibility))

I think the legacy version has the same issue.