### PR TITLE
Fix slider percentage

### DIFF
--- a/packages/renderer-vue/src/nodeinterfaces/slider/SliderInterface.vue
+++ b/packages/renderer-vue/src/nodeinterfaces/slider/SliderInterface.vue
@@ -51,7 +51,7 @@ export default defineComponent({
         const isMouseDown = ref(false);
 
         const percentage = computed(() =>
-            Math.min(100, Math.max(0, (props.intf.value * 100) / (props.intf.max - props.intf.min))),
+            Math.min(100, Math.max(0, ((props.intf.value - props.intf.min) * 100) / (props.intf.max - props.intf.min))),
         );
 
         const mousedown = () => {


### PR DESCRIPTION
It seems that the slider interface assumes here that the min value is `0`, but in baklava1 there was no such assumption.

NOTE: Actually it was also fixed as PR here: https://github.com/newcat/baklavajs/pull/192