### PR TITLE
Fix zoom causes nodes to blur when focus #249

### DIFF
--- a/packages/themes/src/classic/components/node.scss
+++ b/packages/themes/src/classic/components/node.scss
@@ -4,7 +4,6 @@
     color: var(--baklava-node-color-foreground);
     border-radius: var(--baklava-node-border-radius);
     position: absolute;
-    filter: drop-shadow(0 0 3px #000000cc);
     transition: box-shadow var(--baklava-visual-transition), filter var(--baklava-visual-transition);
 
     &:hover {


### PR DESCRIPTION
Fix #249
Remove  `filter: drop-shadow(0 0 3px #000000cc);` from `.baklava-node`.