### PR TITLE
Subgraph Interface Nodes positioning

### DIFF
--- a/packages/renderer-vue/src/graph/saveSubgraph.command.ts
+++ b/packages/renderer-vue/src/graph/saveSubgraph.command.ts
@@ -1,7 +1,11 @@
 import { Ref } from "vue";
 import { Connection, Graph, IGraphInterface } from "@baklavajs/core";
 import type { ICommand, ICommandHandler } from "../commands";
-import { SUBGRAPH_INPUT_NODE_TYPE, SUBGRAPH_OUTPUT_NODE_TYPE, InputNode, OutputNode } from "./subgraphInterfaceNodes";
+import {
+    SUBGRAPH_INPUT_NODE_TYPE,
+    SUBGRAPH_OUTPUT_NODE_TYPE,
+    SubgraphOutputNode, SubgraphInputNode
+} from "./subgraphInterfaceNodes";
 
 export const SAVE_SUBGRAPH_COMMAND = "SAVE_SUBGRAPH";
 export type SaveSubgraphCommand = ICommand<void>;
@@ -17,7 +21,7 @@ export function registerSaveSubgraphCommand(displayedGraph: Ref<Graph>, handler:
         const interfaceConnections: Connection[] = [];
 
         const inputs: IGraphInterface[] = [];
-        const inputNodes = graph.nodes.filter((n) => n.type === SUBGRAPH_INPUT_NODE_TYPE) as InputNode[];
+        const inputNodes = graph.nodes.filter((n) => n.type === SUBGRAPH_INPUT_NODE_TYPE) as unknown as SubgraphInputNode[];
         for (const n of inputNodes) {
             const connections = graph.connections.filter((c) => c.from === n.outputs.placeholder);
             connections.forEach((c) => {
@@ -31,7 +35,7 @@ export function registerSaveSubgraphCommand(displayedGraph: Ref<Graph>, handler:
         }
 
         const outputs: IGraphInterface[] = [];
-        const outputNodes = graph.nodes.filter((n) => n.type === SUBGRAPH_OUTPUT_NODE_TYPE) as OutputNode[];
+        const outputNodes = graph.nodes.filter((n) => n.type === SUBGRAPH_OUTPUT_NODE_TYPE) as unknown as SubgraphOutputNode[];
         for (const n of outputNodes) {
             const connections = graph.connections.filter((c) => c.to === n.inputs.placeholder);
             connections.forEach((c) => {
@@ -45,15 +49,12 @@ export function registerSaveSubgraphCommand(displayedGraph: Ref<Graph>, handler:
         }
 
         const innerConnections = graph.connections.filter((c) => !interfaceConnections.includes(c));
-        const nodes = graph.nodes.filter(
-            (n) => n.type !== SUBGRAPH_INPUT_NODE_TYPE && n.type !== SUBGRAPH_OUTPUT_NODE_TYPE,
-        );
 
         graph.template.update({
             inputs,
             outputs,
             connections: innerConnections.map((c) => ({ id: c.id, from: c.from.id, to: c.to.id })),
-            nodes: nodes.map((n) => n.save()),
+            nodes: graph.nodes.map((n) => n.save()),
             // will be ignored in the update method but still providing them to make TypeScript happy
             panning: graph.panning,
             scaling: graph.scaling,

--- a/packages/renderer-vue/src/graph/subgraphInterfaceNodes.ts
+++ b/packages/renderer-vue/src/graph/subgraphInterfaceNodes.ts
@@ -1,39 +1,80 @@
 import { v4 as uuidv4 } from "uuid";
-import { defineNode, NodeInstanceOf, NodeInterface } from "@baklavajs/core";
+import { INodeState, NodeInstanceOf, NodeInterface, Node } from "@baklavajs/core";
 import { TextInputInterface } from "../nodeinterfaces";
 
 export const SUBGRAPH_INPUT_NODE_TYPE = "__baklava_SubgraphInputNode";
 export const SUBGRAPH_OUTPUT_NODE_TYPE = "__baklava_SubgraphOutputNode";
 
+export interface ISubgraphInterfaceState<I, O> extends INodeState<I, O> {
+    graphInterfaceId: string;
+}
+
+abstract class SubgraphInterfaceNode<I, O> extends Node<I, O> implements ISubgraphInterfaceNode {
+    public graphInterfaceId: string;
+
+    constructor() {
+        super();
+        this.graphInterfaceId = uuidv4();
+    }
+
+    onPlaced() {
+        super.onPlaced();
+
+        this.initializeIo();
+    }
+
+    save(): ISubgraphInterfaceState<I, O> {
+        return {
+            ...super.save(),
+            graphInterfaceId: this.graphInterfaceId,
+        };
+    }
+
+    load(state: ISubgraphInterfaceState<I, O>) {
+        super.load(state as INodeState<I, O>);
+        this.graphInterfaceId = state.graphInterfaceId;
+    }
+}
+
 export interface ISubgraphInterfaceNode {
     graphInterfaceId: string;
 }
 
-export const SubgraphInputNode = defineNode({
-    type: SUBGRAPH_INPUT_NODE_TYPE,
-    title: "Subgraph Input",
-    inputs: {
-        name: () => new TextInputInterface("Name", "Input").setPort(false),
-    },
-    outputs: {
-        placeholder: () => new NodeInterface("Connection", undefined),
-    },
-    onCreate() {
-        (this as unknown as ISubgraphInterfaceNode).graphInterfaceId = uuidv4();
-    },
-});
+interface SubgraphInputNodeInputs {
+    name: string;
+}
 
-export const SubgraphOutputNode = defineNode({
-    type: SUBGRAPH_OUTPUT_NODE_TYPE,
-    title: "Subgraph Output",
-    inputs: {
-        name: () => new TextInputInterface("Name", "Output").setPort(false),
-        placeholder: () => new NodeInterface("Connection", undefined),
-    },
-    onCreate() {
-        (this as unknown as ISubgraphInterfaceNode).graphInterfaceId = uuidv4();
-    },
-});
+interface SubgraphInputNodeOutputs {
+    placeholder: string;
+}
+
+export class SubgraphInputNode extends SubgraphInterfaceNode<SubgraphInputNodeInputs, SubgraphInputNodeOutputs> implements ISubgraphInterfaceNode{
+    public readonly type = SUBGRAPH_INPUT_NODE_TYPE;
+    _title = "Subgraph Input";
+    public inputs = {
+        name: new TextInputInterface("Name", "Input").setPort(false),
+    };
+    public outputs = {
+        placeholder: new NodeInterface("Connection", ''),
+    };
+}
+
+interface SubgraphOutputNodeInputs {
+    name: string;
+    placeholder: string;
+}
+
+interface SubgraphOutputNodeOutputs {}
+
+export class SubgraphOutputNode extends SubgraphInterfaceNode<SubgraphOutputNodeInputs, SubgraphOutputNodeOutputs> implements ISubgraphInterfaceNode{
+    public readonly type = SUBGRAPH_OUTPUT_NODE_TYPE;
+    _title = "Subgraph Output";
+    public inputs = {
+        name: new TextInputInterface("Name", "Output").setPort(false),
+        placeholder: new NodeInterface("Connection", ''),
+    };
+    public outputs = {};
+}
 
 export type InputNode = NodeInstanceOf<typeof SubgraphInputNode> & ISubgraphInterfaceNode;
 export type OutputNode = NodeInstanceOf<typeof SubgraphOutputNode> & ISubgraphInterfaceNode;


### PR DESCRIPTION
– Position IO Nodes of a Subgraph nicely on Subgraph creation.
– Store IO nodes as part of Subgraph template to retain their actual position on Subgraph save.

<img width="883" alt="screenshot_0" src="https://github.com/newcat/baklavajs/assets/464535/84c3f2cf-853e-4e84-94e2-f719c9375225">
<img width="869" alt="screenshot_1" src="https://github.com/newcat/baklavajs/assets/464535/ddf3c092-fa58-49f8-a23b-238a583d8411">
