### PR TITLE
Fix delete not always removing all selected nodes

### DIFF
--- a/packages/renderer-vue/src/graph/deleteNodes.command.ts
+++ b/packages/renderer-vue/src/graph/deleteNodes.command.ts
@@ -9,10 +9,9 @@ export function registerDeleteNodesCommand(displayedGraph: Ref<Graph>, handler: 
     handler.registerCommand(DELETE_NODES_COMMAND, {
         canExecute: () => displayedGraph.value.selectedNodes.length > 0,
         execute() {
-            if(displayedGraph.value.selectedNodes == null) return;
-            for(let i = displayedGraph.value.selectedNodes.length - 1; i >= 0; i--) {
+            for (let i = displayedGraph.value.selectedNodes.length - 1; i >= 0; i--) {
                 const n = displayedGraph.value.selectedNodes[i];
-                displayedGraph.value.removeNode(n)
+                displayedGraph.value.removeNode(n);
             }
         },
     });

--- a/packages/renderer-vue/src/graph/deleteNodes.command.ts
+++ b/packages/renderer-vue/src/graph/deleteNodes.command.ts
@@ -9,7 +9,11 @@ export function registerDeleteNodesCommand(displayedGraph: Ref<Graph>, handler: 
     handler.registerCommand(DELETE_NODES_COMMAND, {
         canExecute: () => displayedGraph.value.selectedNodes.length > 0,
         execute() {
-            displayedGraph.value.selectedNodes.forEach((n) => displayedGraph.value.removeNode(n));
+            if(displayedGraph.value.selectedNodes == null) return;
+            for(let i = displayedGraph.value.selectedNodes.length - 1; i >= 0; i--) {
+                const n = displayedGraph.value.selectedNodes[i];
+                displayedGraph.value.removeNode(n)
+            }
         },
     });
     handler.registerHotkey(["Delete"], DELETE_NODES_COMMAND);


### PR DESCRIPTION
There is an issue when deleting selected nodes using "foreach"
Depending on the order, not all nodes will get deleted, so using a foreach counting down will ensure this does not happen