### PR TITLE
feat: Add getConnections method for retrieving node connections

### DIFF
--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -201,6 +201,22 @@ export class Graph implements IBaklavaEventEmitter, IBaklavaTapable {
         return c;
     }
 
+
+    /**
+     * Get the list of connections associated with the given node.
+     * @param node The node to get the connections for.
+     * @returns The list of connections associated with the given node. If there are no associated connections, an empty array is returned.
+     */
+    public getConnections(node: NodeInterface<any>): Connection[] {
+        return this.connections.filter(item => {
+            if (node.isInput) {
+                return item.to === node;
+            } else {
+                return item.from === node;
+            }
+        })
+    }
+
     /**
      * Remove a connection from the list of connections.
      * @param connection Connection instance that should be removed.

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -203,11 +203,11 @@ export class Graph implements IBaklavaEventEmitter, IBaklavaTapable {
 
 
     /**
-     * Get the list of connections associated with the given node.
-     * @param node The node to get the connections for.
+     * Retrieve the connections associated with a given node.
+     * @param node The node to retrieve the connections for.
      * @returns The list of connections associated with the given node. If there are no associated connections, an empty array is returned.
      */
-    public getConnections(node: NodeInterface<any>): Connection[] {
+    public retrieveNodeConnections(node: NodeInterface<any>): Connection[] {
         return this.connections.filter(item => {
             if (node.isInput) {
                 return item.to === node;


### PR DESCRIPTION
This commit adds the `retrieveNodeConnections` method, which allows retrieving the connections associated with a given node. This functionality is necessary for retrieving and managing the connections of a node, enabling better analysis and manipulation of the node's relationships.