### PR TITLE
chore(renderer-vue):  add export types

### DIFF
--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -14,6 +14,7 @@
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "import": "./dist/renderer-vue.es.mjs",
             "require": "./dist/renderer-vue.umd.cjs"
         }


### PR DESCRIPTION
fix import type error at `"moduleResolution": "bundler"`

![image](https://github.com/newcat/baklavajs/assets/74761884/e0bd63f2-2846-405b-8515-db77d9606ee4)
