### PR TITLE
Add node status attribute for progress visualisation

### DIFF
--- a/docs/visual-editor/customization.md
+++ b/docs/visual-editor/customization.md
@@ -39,6 +39,21 @@ For example, to make all nodes of type `MyNodeType` have a blue background, you 
 }
 ```
 
+Baklava will also create and update the `data-node-staus` attribute to nodes in these situations:
+* When the nodes `calculate` function is running
+* When a `calculate` function has thrown an error
+
+```css
+.baklava-node[data-node-status="error"] {
+    background-color: red;
+}
+.baklava-node[data-node-status="processing"] {
+    background-color: yellow;
+}
+```
+
+This attribute is set to `none` when a node is created and upon successful execution.
+
 ## Custom Components
 
 If these options don't fulfill your needs for customization, you can provide custom components.

--- a/packages/core/src/graphNode.ts
+++ b/packages/core/src/graphNode.ts
@@ -1,7 +1,7 @@
 import { GraphInputNode, GraphOutputNode, IGraphInterface } from "./graphInterface";
 import { type GraphTemplate } from "./graphTemplate";
 import { Graph, IGraphState } from "./graph";
-import { AbstractNode, CalculateFunction, INodeState } from "./node";
+import { AbstractNode, CalculateFunction, INodeState, NodeStatus } from "./node";
 import { NodeInterface } from "./nodeInterface";
 
 export interface IGraphNodeState extends INodeState<any, any> {
@@ -48,6 +48,7 @@ export function createGraphNodeType(template: GraphTemplate): new () => Abstract
 
         public inputs: Record<string, NodeInterface<any>> = {};
         public outputs: Record<string, NodeInterface<any>> = {};
+        public status: NodeStatus = NodeStatus.NONE;
 
         public template = template;
         public subgraph: Graph | undefined;

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -12,6 +12,12 @@ import type { NodeInterfaceDefinition, NodeInterface, NodeInterfaceDefinitionSta
 import { mapValues } from "./utils";
 import { IEngine } from "./engine";
 
+export enum NodeStatus {
+    NONE = "none",
+    PROCESSING = "processing",
+    ERROR = "error"
+}
+
 export interface CalculationContext<G = any, E extends IEngine<G> = IEngine<G>> {
     globalValues: G;
     engine: E;
@@ -28,9 +34,11 @@ export interface INodeState<I, O> {
     type: string;
     title: string;
     id: string;
+    status: NodeStatus;
     inputs: NodeInterfaceDefinitionStates<I> & NodeInterfaceDefinitionStates<Record<string, NodeInterface<any>>>;
     outputs: NodeInterfaceDefinitionStates<O> & NodeInterfaceDefinitionStates<Record<string, NodeInterface<any>>>;
 }
+
 
 export abstract class AbstractNode implements IBaklavaEventEmitter, IBaklavaTapable {
     protected _title = "";
@@ -42,6 +50,8 @@ export abstract class AbstractNode implements IBaklavaEventEmitter, IBaklavaTapa
 
     public abstract inputs: Record<string, NodeInterface<any>>;
     public abstract outputs: Record<string, NodeInterface<any>>;
+    
+    public abstract status: NodeStatus;
 
     public events = {
         loaded: new BaklavaEvent<AbstractNode, AbstractNode>(this),
@@ -156,6 +166,7 @@ export abstract class AbstractNode implements IBaklavaEventEmitter, IBaklavaTapa
         const state: INodeState<any, any> = {
             type: this.type,
             id: this.id,
+            status: this.status,
             title: this.title,
             inputs: inputStates,
             outputs: outputStates,
@@ -238,6 +249,7 @@ export abstract class AbstractNode implements IBaklavaEventEmitter, IBaklavaTapa
 export abstract class Node<I, O> extends AbstractNode {
     public abstract inputs: NodeInterfaceDefinition<I>;
     public abstract outputs: NodeInterfaceDefinition<O>;
+    public status: NodeStatus = NodeStatus.NONE;
 
     public load(state: INodeState<I, O>): void {
         super.load(state);

--- a/packages/core/test/TestNode.ts
+++ b/packages/core/test/TestNode.ts
@@ -1,4 +1,4 @@
-import { AbstractNode, CalculateFunction, Graph, NodeInterface } from "../src";
+import { AbstractNode, CalculateFunction, Graph, NodeInterface, NodeStatus } from "../src";
 
 export default class TestNode extends AbstractNode {
     public type = "TestNode";
@@ -8,6 +8,7 @@ export default class TestNode extends AbstractNode {
     public outputs = {
         b: new NodeInterface("B", 2),
     };
+    public status = NodeStatus.NONE
 
     public constructor() {
         super();

--- a/packages/engine/src/dependencyEngine.ts
+++ b/packages/engine/src/dependencyEngine.ts
@@ -1,4 +1,5 @@
-import { Editor, Graph, NodeInterface, CalculationResult, NodeStatus } from "@baklavajs/core";
+import type { Editor, Graph, NodeInterface, CalculationResult } from "@baklavajs/core";
+import {NodeStatus} from "@baklavajs/core"
 import { BaseEngine } from "./baseEngine";
 import { ITopologicalSortingResult, sortTopologically } from "./topologicalSorting";
 
@@ -54,6 +55,7 @@ export class DependencyEngine<CalculationData = any> extends BaseEngine<Calculat
                 n.status = NodeStatus.NONE
             } catch (error) {
                 n.status = NodeStatus.ERROR
+                throw error
             }
             
             this.events.afterNodeCalculation.emit({ outputValues: r, node: n });

--- a/packages/renderer-vue/src/index.ts
+++ b/packages/renderer-vue/src/index.ts
@@ -5,7 +5,6 @@
 export * from "./overrides";
 
 export * from "./editor";
-export * from "./contextmenu"
 export * from "./commands";
 export * from "./nodeinterfaces";
 export * from "./viewModel";

--- a/packages/renderer-vue/src/index.ts
+++ b/packages/renderer-vue/src/index.ts
@@ -5,6 +5,7 @@
 export * from "./overrides";
 
 export * from "./editor";
+export * from "./contextmenu"
 export * from "./commands";
 export * from "./nodeinterfaces";
 export * from "./viewModel";

--- a/packages/renderer-vue/src/node/Node.vue
+++ b/packages/renderer-vue/src/node/Node.vue
@@ -6,6 +6,7 @@
         :class="classes"
         :style="styles"
         :data-node-type="node.type"
+        :data-node-status="node.status"
         @pointerdown="select"
     >
         <div v-if="viewModel.settings.nodes.resizable" class="__resize-handle" @mousedown="startResize" />


### PR DESCRIPTION
We have a slightly different use-case for this library, where the engine is triggered manually and a run of a graph can take seconds to minutes. Part of this process can include calls out to 3rd-party API's, which may or may not respond nicely.
Due to this, its useful to be able to see:
A) Which node is being executed, as it is happening
B) Which node threw an error and halted execution.

This PR adds a ```status``` attribute to AbstractNode, that is percolated through to a `data-node-status` attribute in the DOM. The consumer can then simply create the following css to indicate these statuses:
```
.baklava-node[data-node-status="processing"] {
     outline: .5em yellow solid
}
