### PR TITLE
Add CSS custom property for port color

### DIFF
--- a/docs/nodes/interface-types.md
+++ b/docs/nodes/interface-types.md
@@ -114,16 +114,16 @@ This attribute can be used to style the interfaces using CSS.
 Here is an example of how to set the color of the ports depending on the interface type:
 
 ```css
-.baklava-node-interface[data-interface-type="string"] .__port {
-    background-color: green;
+.baklava-node-interface[data-interface-type="string"] {
+    --baklava-node-interface-port-color: green;
 }
 
-.baklava-node-interface[data-interface-type="number"] .__port {
-    background-color: red;
+.baklava-node-interface[data-interface-type="number"] {
+    --baklava-node-interface-port-color: red;
 }
 
-.baklava-node-interface[data-interface-type="boolean"] .__port {
-    background-color: purple;
+.baklava-node-interface[data-interface-type="boolean"] {
+    --baklava-node-interface-port-color: purple;
 }
 ```
 

--- a/packages/renderer-vue/playground/interfaceTypes.css
+++ b/packages/renderer-vue/playground/interfaceTypes.css
@@ -1,11 +1,11 @@
-.baklava-node-interface[data-interface-type="string"] .__port {
-    background-color: green;
+.baklava-node-interface[data-interface-type="string"] {
+    --baklava-node-interface-port-color: green;
 }
 
-.baklava-node-interface[data-interface-type="number"] .__port {
-    background-color: red;
+.baklava-node-interface[data-interface-type="number"] {
+    --baklava-node-interface-port-color: red;
 }
 
-.baklava-node-interface[data-interface-type="boolean"] .__port {
-    background-color: purple;
+.baklava-node-interface[data-interface-type="boolean"] {
+    --baklava-node-interface-port-color: purple;
 }

--- a/packages/themes/src/classic/components/node-interface.scss
+++ b/packages/themes/src/classic/components/node-interface.scss
@@ -6,7 +6,7 @@
         position: absolute;
         width: 10px;
         height: 10px;
-        background: white;
+        background: var(--baklava-node-interface-port-color);
         border-radius: 50%;
         top: calc(50% - 5px);
         cursor: crosshair;

--- a/packages/themes/src/classic/variables.scss
+++ b/packages/themes/src/classic/variables.scss
@@ -23,6 +23,7 @@
     --baklava-node-title-color-foreground: white;
     --baklava-group-node-title-color-background: rgb(5, 75, 5);
     --baklava-group-node-title-color-foreground: white;
+    --baklava-node-interface-port-color: white;
     --baklava-node-interface-port-tooltip-color-foreground: var(--baklava-control-color-primary);
     --baklava-node-interface-port-tooltip-color-background: var(--baklava-editor-background-pattern-black);
     --baklava-node-border-radius: 4px;

--- a/packages/themes/src/syrup-dark/variables.scss
+++ b/packages/themes/src/syrup-dark/variables.scss
@@ -23,6 +23,7 @@
     --baklava-node-title-color-foreground: white;
     --baklava-group-node-title-color-background: #215636;
     --baklava-group-node-title-color-foreground: white;
+    --baklava-node-interface-port-color: white;
     --baklava-node-interface-port-tooltip-color-foreground: var(--baklava-control-color-primary);
     --baklava-node-interface-port-tooltip-color-background: var(--baklava-editor-background-pattern-black);
     --baklava-node-border-radius: 6px;


### PR DESCRIPTION
I have added a new CSS custom property: `--baklava-node-interface-port-color`. This makes it easier to change the port color in custom themes or when changing the port color based on its interface type.

In the classic and syrup dark themes, the value has been set to white, matching the original color.