### PR TITLE
Add command to clear history

### DIFF
--- a/packages/renderer-vue/playground/App.vue
+++ b/packages/renderer-vue/playground/App.vue
@@ -14,6 +14,7 @@
         <button @click="createSubgraph">Create Subgraph</button>
         <button @click="saveAndLoad">Save and Load</button>
         <button @click="changeSidebarWidth">SidebarWidth</button>
+        <button @click="clearHistory">Clear History</button>
     </div>
 </template>
 
@@ -148,6 +149,10 @@ const createSubgraph = () => {
 const changeSidebarWidth = () => {
     baklavaView.settings.sidebar.width = Math.round(Math.random() * 500) + 300;
     baklavaView.settings.sidebar.resizable = !baklavaView.settings.sidebar.resizable;
+};
+
+const clearHistory = () => {
+    baklavaView.commandHandler.executeCommand<Commands.ClearHistoryCommand>(Commands.CLEAR_HISTORY_COMMAND);
 };
 </script>
 

--- a/packages/renderer-vue/src/commandList.ts
+++ b/packages/renderer-vue/src/commandList.ts
@@ -1,5 +1,5 @@
 export type { CreateSubgraphCommand, DeleteNodesCommand, SaveSubgraphCommand, SwitchToMainGraphCommand } from "./graph";
-export type { CommitTransactionCommand, StartTransactionCommand, UndoCommand, RedoCommand } from "./history";
+export type { ClearHistoryCommand, CommitTransactionCommand, StartTransactionCommand, UndoCommand, RedoCommand } from "./history";
 export type { ClearClipboardCommand, CopyCommand, PasteCommand } from "./clipboard";
 export type { OpenSidebarCommand } from "./sidebar";
 export type { StartSelectionBoxCommand } from "./editor/selectionBox";
@@ -10,7 +10,7 @@ export {
     SAVE_SUBGRAPH_COMMAND,
     SWITCH_TO_MAIN_GRAPH_COMMAND,
 } from "./graph";
-export { COMMIT_TRANSACTION_COMMAND, START_TRANSACTION_COMMAND, UNDO_COMMAND, REDO_COMMAND } from "./history";
+export { CLEAR_HISTORY_COMMAND, COMMIT_TRANSACTION_COMMAND, START_TRANSACTION_COMMAND, UNDO_COMMAND, REDO_COMMAND } from "./history";
 export { CLEAR_CLIPBOARD_COMMAND, COPY_COMMAND, PASTE_COMMAND } from "./clipboard";
 export { OPEN_SIDEBAR_COMMAND } from "./sidebar";
 export { START_SELECTION_BOX_COMMAND } from "./editor/selectionBox";

--- a/packages/renderer-vue/src/history/index.ts
+++ b/packages/renderer-vue/src/history/index.ts
@@ -12,11 +12,13 @@ export const UNDO_COMMAND = "UNDO";
 export const REDO_COMMAND = "REDO";
 export const START_TRANSACTION_COMMAND = "START_TRANSACTION";
 export const COMMIT_TRANSACTION_COMMAND = "COMMIT_TRANSACTION";
+export const CLEAR_HISTORY_COMMAND = "CLEAR_HISTORY";
 
 export type UndoCommand = ICommand<void>;
 export type RedoCommand = ICommand<void>;
 export type StartTransactionCommand = ICommand<void>;
 export type CommitTransactionCommand = ICommand<void>;
+export type ClearHistoryCommand = ICommand<void>;
 
 export interface IHistory {
     maxSteps: number;
@@ -86,6 +88,11 @@ export function useHistory(graph: Ref<Graph>, commandHandler: ICommandHandler): 
         changeBySelf.value = false;
     };
 
+    const clear = () => {
+        steps.value = [];
+        currentIndex.value = -1;
+    };
+
     watch(
         graph,
         (newGraph, oldGraph) => {
@@ -129,6 +136,10 @@ export function useHistory(graph: Ref<Graph>, commandHandler: ICommandHandler): 
     commandHandler.registerCommand<CommitTransactionCommand>(COMMIT_TRANSACTION_COMMAND, {
         canExecute: () => activeTransaction.value,
         execute: commitTransaction,
+    });
+    commandHandler.registerCommand<ClearHistoryCommand>(CLEAR_HISTORY_COMMAND, {
+        canExecute: () => steps.value.length > 0,
+        execute: clear,
     });
 
     commandHandler.registerHotkey(["Control", "z"], UNDO_COMMAND);


### PR DESCRIPTION
I have added a command that clears the history in the undo stack. This is something you might want to do after loading a new graph, to prevent users undoing to a state where the previous graph was loaded.

I chose not to clear the active transaction when the command is executed. My reasoning is that an active transaction is not yet committed to history and so should not be cleared. Anyway, I don't imagine it would be common to clear the history while a transaction is in progress.

P.S. This is an amazing library. Thanks for all your work on it!