### PR TITLE
Fix undo not working after max steps exceeded

### DIFF
--- a/packages/renderer-vue/src/history/index.ts
+++ b/packages/renderer-vue/src/history/index.ts
@@ -46,11 +46,12 @@ export function useHistory(graph: Ref<Graph>, commandHandler: ICommandHandler): 
             }
 
             steps.value.push(step);
-            currentIndex.value++;
 
             while (steps.value.length > maxSteps.value) {
                 steps.value.shift();
             }
+
+            currentIndex.value = steps.value.length - 1;
         }
     };
 


### PR DESCRIPTION
The bug I observed was that, after exceeding `maxSteps`, the `currentIndex` would still be incremented even though a step was discarded from the bottom of the stack. Then when you tried to undo, it tried to index into the array at an invalid index.