### PR TITLE
Improve resizing UX after dragging past the min and max widths

### DIFF
--- a/packages/renderer-vue/src/node/Node.vue
+++ b/packages/renderer-vue/src/node/Node.vue
@@ -94,6 +94,8 @@ const renaming = ref(false);
 const tempName = ref("");
 const renameInputEl = ref<HTMLInputElement | null>(null);
 const isResizing = ref(false);
+let resizeStartWidth = 0;
+let resizeStartMouseX = 0;
 
 const showContextMenu = ref(false);
 const contextMenuItems = computed(() => {
@@ -174,12 +176,15 @@ const onRender = () => {
 
 const startResize = (ev: MouseEvent) => {
     isResizing.value = true;
+    resizeStartWidth = props.node.width;
+    resizeStartMouseX = ev.clientX;
     ev.preventDefault();
 };
 
 const doResize = (ev: MouseEvent) => {
     if (!isResizing.value) return;
-    const newWidth = props.node.width + ev.movementX / graph.value.scaling;
+    const deltaX = ev.clientX - resizeStartMouseX;
+    const newWidth = resizeStartWidth + deltaX / graph.value.scaling;
     const minWidth = viewModel.value.settings.nodes.minWidth;
     const maxWidth = viewModel.value.settings.nodes.maxWidth;
     props.node.width = Math.max(minWidth, Math.min(maxWidth, newWidth));

--- a/packages/renderer-vue/src/sidebar/Sidebar.vue
+++ b/packages/renderer-vue/src/sidebar/Sidebar.vue
@@ -28,6 +28,8 @@ export default defineComponent({
 
         const width = toRef(viewModel.value.settings.sidebar, "width");
         const resizable = computed(() => viewModel.value.settings.sidebar.resizable);
+        let resizeStartWidth = 0;
+        let resizeStartMouseX = 0;
 
         const node = computed(() => {
             const id = graph.value.sidebar.nodeId;
@@ -50,7 +52,9 @@ export default defineComponent({
             graph.value.sidebar.visible = false;
         };
 
-        const startResize = () => {
+        const startResize = (event: MouseEvent) => {
+            resizeStartWidth = width.value;
+            resizeStartMouseX = event.clientX;
             window.addEventListener("mousemove", onMouseMove);
             window.addEventListener(
                 "mouseup",
@@ -63,7 +67,8 @@ export default defineComponent({
 
         const onMouseMove = (event: MouseEvent) => {
             const maxwidth = el.value?.parentElement?.getBoundingClientRect().width ?? 500;
-            let newWidth = width.value - event.movementX;
+            const deltaX = event.clientX - resizeStartMouseX;
+            let newWidth = resizeStartWidth - deltaX;
             if (newWidth < 300) {
                 newWidth = 300;
             } else if (newWidth > 0.9 * maxwidth) {


### PR DESCRIPTION
When resizing a node or the sidebar, if you dragged past the min or max width, and then dragged back in the opposite direction, the node/sidebar would immediately start to resize, regardless of where your mouse was.

It's a bit difficult to explain in words, so here are before and after videos showing the change this PR makes.

https://github.com/user-attachments/assets/9a738f40-d352-4e33-adca-213f6250b97c

https://github.com/user-attachments/assets/16d4e924-d794-4cd3-84bb-1064c990a6d8

