### PR TITLE
Add named export for getDomElements

### DIFF
--- a/packages/renderer-vue/src/components/Minimap.vue
+++ b/packages/renderer-vue/src/components/Minimap.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { AbstractNode } from "@baklavajs/core";
-import getDomElements, { getDomElementOfNode } from "../connection/domResolver";
+import { getDomElements, getDomElementOfNode } from "../connection/domResolver";
 import { getPortCoordinates } from "../connection/portCoordinates";
 import { useGraph, useViewModel } from "../utility";
 

--- a/packages/renderer-vue/src/connection/ConnectionWrapper.vue
+++ b/packages/renderer-vue/src/connection/ConnectionWrapper.vue
@@ -6,7 +6,7 @@
 import { computed, defineComponent, ref, onBeforeUnmount, onMounted, nextTick, watch } from "vue";
 import { Connection } from "@baklavajs/core";
 import ConnectionView from "./ConnectionView.vue";
-import resolveDom, { IResolvedDomElements } from "./domResolver";
+import { getDomElements, IResolvedDomElements } from "./domResolver";
 import { TemporaryConnectionState } from "./connection";
 import { useGraph } from "../utility";
 
@@ -51,8 +51,8 @@ export default defineComponent({
         };
 
         const updateCoords = () => {
-            const from = resolveDom(props.connection.from);
-            const to = resolveDom(props.connection.to);
+            const from = getDomElements(props.connection.from);
+            const to = getDomElements(props.connection.to);
             if (from.node && to.node) {
                 if (!resizeObserver) {
                     resizeObserver = new ResizeObserver(() => {

--- a/packages/renderer-vue/src/connection/TemporaryConnection.vue
+++ b/packages/renderer-vue/src/connection/TemporaryConnection.vue
@@ -14,7 +14,7 @@ import { computed, defineComponent } from "vue";
 
 import ConnectionView from "./ConnectionView.vue";
 import { ITemporaryConnection, TemporaryConnectionState } from "./connection";
-import resolveDom from "./domResolver";
+import { getDomElements } from "./domResolver";
 import { getPortCoordinates } from "./portCoordinates";
 
 export default defineComponent({
@@ -38,9 +38,9 @@ export default defineComponent({
                 };
             }
 
-            const start = getPortCoordinates(resolveDom(props.connection.from));
+            const start = getPortCoordinates(getDomElements(props.connection.from));
             const end = props.connection.to
-                ? getPortCoordinates(resolveDom(props.connection.to))
+                ? getPortCoordinates(getDomElements(props.connection.to))
                 : [props.connection.mx || start[0], props.connection.my || start[1]];
 
             if (props.connection.from.isInput) {

--- a/packages/renderer-vue/src/connection/domResolver.ts
+++ b/packages/renderer-vue/src/connection/domResolver.ts
@@ -20,4 +20,3 @@ export function getDomElements(ni: NodeInterface): IResolvedDomElements {
         port: portDOM && portDOM.length > 0 ? (portDOM[0] as HTMLElement) : null,
     };
 }
-export default getDomElements;

--- a/packages/renderer-vue/src/connection/domResolver.ts
+++ b/packages/renderer-vue/src/connection/domResolver.ts
@@ -10,7 +10,7 @@ export function getDomElementOfNode(node: AbstractNode): HTMLElement | null {
     return document.getElementById(node.id);
 }
 
-export default function getDomElements(ni: NodeInterface): IResolvedDomElements {
+export function getDomElements(ni: NodeInterface): IResolvedDomElements {
     const interfaceDOM = document.getElementById(ni.id);
     const portDOM = interfaceDOM?.getElementsByClassName("__port");
 
@@ -20,3 +20,4 @@ export default function getDomElements(ni: NodeInterface): IResolvedDomElements 
         port: portDOM && portDOM.length > 0 ? (portDOM[0] as HTMLElement) : null,
     };
 }
+export default getDomElements;


### PR DESCRIPTION
So that the method is accessible from the outside, at least useful to fully customize ConnectionWrapper.

Also, kept it as default to not break anything.

It completes work done in https://github.com/newcat/baklavajs/issues/408.

Really tiny PR but I felt bad only commenting issues. Also it made me pretty sure I don't mess with anything ^^
If you want to do it your way, feel free to take or rework that change !

PS: I prepared changes to delete default export inside domResolver, to have only named exports. If you think it would be better, let me know so that I can push it.