### PR TITLE
Add settings for customizing toolbar commands

### DIFF
--- a/docs/visual-editor/toolbar.md
+++ b/docs/visual-editor/toolbar.md
@@ -1,2 +1,177 @@
 # Toolbar
 
+The toolbar provides a set of clickable buttons for common editor operations. BaklavaJS includes a default set of commands like copy, paste, undo, redo, and more that can be customized to fit your application's needs.
+
+## Default Toolbar
+
+By default, the toolbar includes these commands:
+
+- Copy - Copy selected nodes
+- Paste - Paste copied nodes
+- Delete Selected Nodes - Remove selected nodes from the graph
+- Undo - Revert the last action
+- Redo - Reapply a reverted action
+- Zoom to Fit - Adjust the view to fit all nodes
+- Box Select - Enable box selection mode
+- Create Subgraph - Create a subgraph from selected nodes
+
+## Enabling/Disabling the Toolbar
+
+You can enable or disable the toolbar through view settings:
+
+```typescript
+// Enable toolbar
+baklavaView.settings.toolbar.enabled = true;
+
+// Disable toolbar
+baklavaView.settings.toolbar.enabled = false;
+```
+
+## Using a Subset of Default Commands
+
+If you want to use only specific default commands, you can import `TOOLBAR_COMMANDS` and select just the ones you need:
+
+```typescript
+import { useBaklava, TOOLBAR_COMMANDS } from "@baklavajs/renderer-vue";
+
+const baklavaView = useBaklava();
+
+// Use only copy, paste, and undo commands
+baklavaView.settings.toolbar.commands = [TOOLBAR_COMMANDS.COPY, TOOLBAR_COMMANDS.PASTE, TOOLBAR_COMMANDS.UNDO];
+```
+
+## Adding Custom Commands
+
+You can add your own custom commands to the toolbar by:
+
+1. Registering a new command with the command handler
+2. Creating a toolbar command object
+3. Adding it to the toolbar commands array
+
+```typescript
+import { useBaklava, DEFAULT_TOOLBAR_COMMANDS } from "@baklavajs/renderer-vue";
+import { defineComponent, h } from "vue";
+
+const baklavaView = useBaklava();
+
+// 1. Register a custom command
+const CLEAR_ALL_COMMAND = "CLEAR_ALL";
+baklavaView.commandHandler.registerCommand(CLEAR_ALL_COMMAND, {
+    execute: () => {
+        // Clear all nodes from the graph
+        baklavaView.displayedGraph.nodes.forEach((node) => {
+            baklavaView.displayedGraph.removeNode(node);
+        });
+    },
+    // Optional: Define when the command can be executed
+    canExecute: () => baklavaView.displayedGraph.nodes.length > 0,
+});
+
+// 2. & 3. Add the command to the toolbar
+baklavaView.settings.toolbar.commands = [
+    ...DEFAULT_TOOLBAR_COMMANDS,
+    {
+        command: CLEAR_ALL_COMMAND,
+        title: "Clear All", // Tooltip text
+        icon: defineComponent(() => {
+            return () => h("div", "Clear All");
+        }),
+    },
+];
+```
+
+## Creating Icons for Custom Commands
+
+You can create custom icons for your toolbar commands in several ways:
+
+1. Using a Vue component:
+
+```typescript
+import { defineComponent, h } from "vue";
+
+const ClearAllIcon = defineComponent(() => {
+  return () => h("div", { class: "my-icon-class" }, "X");
+});
+
+// Use the component as the icon
+{
+  command: CLEAR_ALL_COMMAND,
+  title: "Clear All",
+  icon: ClearAllIcon
+}
+```
+
+2. Using an SVG icon library:
+
+```typescript
+import { TrashIcon } from "@heroicons/vue/24/outline";
+
+// Use the imported icon component directly
+{
+  command: CLEAR_ALL_COMMAND,
+  title: "Clear All",
+  icon: TrashIcon
+}
+```
+
+## Subgraph Toolbar Commands
+
+When working with subgraphs, BaklavaJS provides special commands for navigating and working with them:
+
+```typescript
+import { TOOLBAR_SUBGRAPH_COMMANDS } from "@baklavajs/renderer-vue";
+
+// Default subgraph commands include:
+// - SAVE_SUBGRAPH: Save changes to the subgraph
+// - SWITCH_TO_MAIN_GRAPH: Return to the main graph
+
+// You can customize the subgraph toolbar:
+baklavaView.settings.toolbar.subgraphCommands = [
+    TOOLBAR_SUBGRAPH_COMMANDS.SWITCH_TO_MAIN_GRAPH,
+    // Add your custom subgraph commands here
+];
+```
+
+## Complete Toolbar Customization Example
+
+Here's a complete example showing how to customize the toolbar:
+
+```typescript
+import { useBaklava, TOOLBAR_COMMANDS, TOOLBAR_SUBGRAPH_COMMANDS } from "@baklavajs/renderer-vue";
+import { defineComponent, h } from "vue";
+
+const baklavaView = useBaklava();
+
+// Register a custom command
+const TOGGLE_MINIMAP_COMMAND = "TOGGLE_MINIMAP";
+baklavaView.commandHandler.registerCommand(TOGGLE_MINIMAP_COMMAND, {
+    execute: () => {
+        baklavaView.settings.enableMinimap = !baklavaView.settings.enableMinimap;
+    },
+    canExecute: () => true,
+});
+
+// Customize the toolbar with a mix of default and custom commands
+baklavaView.settings.toolbar.commands = [
+    TOOLBAR_COMMANDS.COPY,
+    TOOLBAR_COMMANDS.PASTE,
+    TOOLBAR_COMMANDS.DELETE_NODES,
+    TOOLBAR_COMMANDS.UNDO,
+    TOOLBAR_COMMANDS.REDO,
+    {
+        command: TOGGLE_MINIMAP_COMMAND,
+        title: "Toggle Minimap",
+        icon: defineComponent(() => {
+            return () => h("div", "Map");
+        }),
+    },
+];
+
+// Customize subgraph commands
+baklavaView.settings.toolbar.subgraphCommands = [
+    TOOLBAR_SUBGRAPH_COMMANDS.SAVE_SUBGRAPH,
+    TOOLBAR_SUBGRAPH_COMMANDS.SWITCH_TO_MAIN_GRAPH,
+];
+```
+
+By following these patterns, you can fully customize the toolbar to meet your application's specific needs.

--- a/packages/renderer-vue/playground/App.vue
+++ b/packages/renderer-vue/playground/App.vue
@@ -21,7 +21,7 @@
 
 <script setup lang="ts">
 import { NodeInstanceOf } from "@baklavajs/core";
-import { BaklavaEditor, Components, SelectInterface, useBaklava, Commands } from "../src";
+import { BaklavaEditor, Components, SelectInterface, useBaklava, Commands, DEFAULT_TOOLBAR_COMMANDS } from "../src";
 import { DependencyEngine, applyResult } from "@baklavajs/engine";
 import { BaklavaInterfaceTypes } from "@baklavajs/interface-types";
 
@@ -44,6 +44,7 @@ import ReactiveOutputTestNode from "./ReactiveOutputTestNode";
 import { stringType, numberType, booleanType } from "./interfaceTypes";
 
 import CommentNodeRenderer from "./CommentNodeRenderer.vue";
+import { defineComponent, h } from "vue";
 
 const NodeComponent = Components.Node;
 
@@ -63,6 +64,26 @@ baklavaView.settings.contextMenu.additionalItems = [
     { label: "Paste", command: Commands.PASTE_COMMAND },
 ];
 
+const CLEAR_ALL_COMMAND = "CLEAR_ALL";
+baklavaView.commandHandler.registerCommand(CLEAR_ALL_COMMAND, {
+    execute: () => {
+        baklavaView.displayedGraph.nodes.forEach((node) => {
+            baklavaView.displayedGraph.removeNode(node);
+        });
+    },
+    canExecute: () => baklavaView.displayedGraph.nodes.length > 0,
+});
+baklavaView.settings.toolbar.commands = [
+    ...DEFAULT_TOOLBAR_COMMANDS,
+    {
+        command: CLEAR_ALL_COMMAND,
+        title: "Clear All",
+        icon: defineComponent(() => {
+            return () => h("div", "Clear All");
+        }),
+    },
+];
+
 const engine = new DependencyEngine(editor);
 engine.events.afterRun.subscribe(token, (r) => {
     engine.pause();
@@ -73,10 +94,7 @@ engine.events.afterRun.subscribe(token, (r) => {
 engine.hooks.gatherCalculationData.subscribe(token, () => "def");
 engine.start();
 
-const nodeInterfaceTypes = new BaklavaInterfaceTypes(editor, {
-    viewPlugin: baklavaView,
-    engine,
-});
+const nodeInterfaceTypes = new BaklavaInterfaceTypes(editor, { viewPlugin: baklavaView, engine });
 nodeInterfaceTypes.addTypes(stringType, numberType, booleanType);
 
 editor.registerNodeType(TestNode, { category: "Tests" });
@@ -163,8 +181,12 @@ const zoomToFitRandomNode = () => {
 
     const nodes = baklavaView.displayedGraph.nodes;
     const node = nodes[Math.floor(Math.random() * nodes.length)];
-    baklavaView.commandHandler.executeCommand<Commands.ZoomToFitNodesCommand>(Commands.ZOOM_TO_FIT_NODES_COMMAND, true, [node]);
-}
+    baklavaView.commandHandler.executeCommand<Commands.ZoomToFitNodesCommand>(
+        Commands.ZOOM_TO_FIT_NODES_COMMAND,
+        true,
+        [node],
+    );
+};
 </script>
 
 <style>

--- a/packages/renderer-vue/src/index.ts
+++ b/packages/renderer-vue/src/index.ts
@@ -8,6 +8,7 @@ export * from "./editor";
 export * from "./commands";
 export * from "./connection";
 export * from "./nodeinterfaces";
+export * from "./toolbar";
 export * from "./viewModel";
 export * from "./utility";
 export { displayInSidebar } from "./sidebar";

--- a/packages/renderer-vue/src/settings.ts
+++ b/packages/renderer-vue/src/settings.ts
@@ -1,3 +1,5 @@
+import type { Component } from "vue";
+
 interface SimpleContextMenuItem {
     label: string;
     command: string;
@@ -10,6 +12,12 @@ interface DividerContextMenuItem {
 interface SubmenuContextMenuItem {
     label: string;
     submenu: ContextMenuItem[];
+}
+
+interface ToolbarCommand {
+    command: string;
+    title: string;
+    icon?: Component;
 }
 
 export type ContextMenuItem = SimpleContextMenuItem | DividerContextMenuItem | SubmenuContextMenuItem;
@@ -25,6 +33,10 @@ export interface IViewSettings {
     toolbar: {
         /** Whether the toolbar should be enabled */
         enabled: boolean;
+        useDefaultCommands: boolean;
+        useDefaultSubgraphCommands: boolean;
+        additionalCommands: ToolbarCommand[];
+        additionalSubgraphCommands: ToolbarCommand[];
     };
 
     /** Palette settings */
@@ -81,6 +93,10 @@ export const DEFAULT_SETTINGS: () => IViewSettings = () => ({
     enableMinimap: false,
     toolbar: {
         enabled: true,
+        useDefaultCommands: true,
+        useDefaultSubgraphCommands: true,
+        additionalCommands: [],
+        additionalSubgraphCommands: [],
     },
     palette: {
         enabled: true,

--- a/packages/renderer-vue/src/settings.ts
+++ b/packages/renderer-vue/src/settings.ts
@@ -1,4 +1,4 @@
-import type { Component } from "vue";
+import { DEFAULT_TOOLBAR_COMMANDS, DEFAULT_TOOLBAR_SUBGRAPH_COMMANDS, ToolbarCommand } from "./toolbar";
 
 interface SimpleContextMenuItem {
     label: string;
@@ -14,12 +14,6 @@ interface SubmenuContextMenuItem {
     submenu: ContextMenuItem[];
 }
 
-interface ToolbarCommand {
-    command: string;
-    title: string;
-    icon?: Component;
-}
-
 export type ContextMenuItem = SimpleContextMenuItem | DividerContextMenuItem | SubmenuContextMenuItem;
 
 export interface IViewSettings {
@@ -33,10 +27,8 @@ export interface IViewSettings {
     toolbar: {
         /** Whether the toolbar should be enabled */
         enabled: boolean;
-        useDefaultCommands: boolean;
-        useDefaultSubgraphCommands: boolean;
-        additionalCommands: ToolbarCommand[];
-        additionalSubgraphCommands: ToolbarCommand[];
+        commands: ToolbarCommand[];
+        subgraphCommands: ToolbarCommand[];
     };
 
     /** Palette settings */
@@ -46,11 +38,7 @@ export interface IViewSettings {
     };
 
     /** Background settings */
-    background: {
-        gridSize: number;
-        gridDivision: number;
-        subGridVisibleThreshold: number;
-    };
+    background: { gridSize: number; gridDivision: number; subGridVisibleThreshold: number };
     /** Sidebar settings */
     sidebar: {
         /** Whether the sidebar should be enabled */
@@ -80,53 +68,18 @@ export interface IViewSettings {
         enabled: boolean;
         additionalItems: ContextMenuItem[];
     };
-    zoomToFit: {
-        paddingLeft: number;
-        paddingRight: number;
-        paddingTop: number;
-        paddingBottom: number;
-    };
+    zoomToFit: { paddingLeft: number; paddingRight: number; paddingTop: number; paddingBottom: number };
 }
 
 export const DEFAULT_SETTINGS: () => IViewSettings = () => ({
     useStraightConnections: false,
     enableMinimap: false,
-    toolbar: {
-        enabled: true,
-        useDefaultCommands: true,
-        useDefaultSubgraphCommands: true,
-        additionalCommands: [],
-        additionalSubgraphCommands: [],
-    },
-    palette: {
-        enabled: true,
-    },
-    background: {
-        gridSize: 100,
-        gridDivision: 5,
-        subGridVisibleThreshold: 0.6,
-    },
-    sidebar: {
-        enabled: true,
-        width: 300,
-        resizable: true,
-    },
+    toolbar: { enabled: true, commands: DEFAULT_TOOLBAR_COMMANDS, subgraphCommands: DEFAULT_TOOLBAR_SUBGRAPH_COMMANDS },
+    palette: { enabled: true },
+    background: { gridSize: 100, gridDivision: 5, subGridVisibleThreshold: 0.6 },
+    sidebar: { enabled: true, width: 300, resizable: true },
     displayValueOnHover: false,
-    nodes: {
-        defaultWidth: 200,
-        maxWidth: 320,
-        minWidth: 150,
-        resizable: false,
-        reverseY: false,
-    },
-    contextMenu: {
-        enabled: true,
-        additionalItems: [],
-    },
-    zoomToFit: {
-        paddingLeft: 300,
-        paddingRight: 50,
-        paddingTop: 110,
-        paddingBottom: 50,
-    },
+    nodes: { defaultWidth: 200, maxWidth: 320, minWidth: 150, resizable: false, reverseY: false },
+    contextMenu: { enabled: true, additionalItems: [] },
+    zoomToFit: { paddingLeft: 300, paddingRight: 50, paddingTop: 110, paddingBottom: 50 },
 });

--- a/packages/renderer-vue/src/toolbar/Toolbar.vue
+++ b/packages/renderer-vue/src/toolbar/Toolbar.vue
@@ -14,77 +14,13 @@
     </div>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, Component } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { useViewModel } from "../utility";
-import {
-    COPY_COMMAND,
-    PASTE_COMMAND,
-    UNDO_COMMAND,
-    REDO_COMMAND,
-    CREATE_SUBGRAPH_COMMAND,
-    SAVE_SUBGRAPH_COMMAND,
-    START_SELECTION_BOX_COMMAND,
-    DELETE_NODES_COMMAND,
-    SWITCH_TO_MAIN_GRAPH_COMMAND,
-    ZOOM_TO_FIT_GRAPH_COMMAND,
-} from "../commandList";
-import * as Icons from "../icons";
 import ToolbarButton from "./ToolbarButton.vue";
 
-interface ToolbarCommand {
-    command: string;
-    title: string;
-    icon?: Component;
-}
-
-export default defineComponent({
-    components: { ToolbarButton },
-    setup() {
-        const { viewModel } = useViewModel();
-
-        const isSubgraph = computed(() => viewModel.value.displayedGraph !== viewModel.value.editor.graph);
-
-        const commands = computed(() => {
-            const commands: ToolbarCommand[] = [];
-
-            if (viewModel.value.settings.toolbar.useDefaultCommands) {
-                commands.push(
-                    { command: COPY_COMMAND, title: "Copy", icon: Icons.Copy },
-                    { command: PASTE_COMMAND, title: "Paste", icon: Icons.Clipboard },
-                    { command: DELETE_NODES_COMMAND, title: "Delete selected nodes", icon: Icons.Trash },
-                    { command: UNDO_COMMAND, title: "Undo", icon: Icons.ArrowBackUp },
-                    { command: REDO_COMMAND, title: "Redo", icon: Icons.ArrowForwardUp },
-                    { command: ZOOM_TO_FIT_GRAPH_COMMAND, title: "Zoom to Fit", icon: Icons.ZoomScan },
-                    { command: START_SELECTION_BOX_COMMAND, title: "Box Select", icon: Icons.SelectAll },
-                );
-            }
-
-            commands.push(...viewModel.value.settings.toolbar.additionalCommands);
-
-            if (viewModel.value.settings.toolbar.useDefaultCommands) {
-                commands.push({ command: CREATE_SUBGRAPH_COMMAND, title: "Create Subgraph", icon: Icons.Hierarchy2 });
-            }
-
-            return commands;
-        });
-
-        const subgraphCommands = computed(() => {
-            const commands: ToolbarCommand[] = [];
-
-            if (viewModel.value.settings.toolbar.useDefaultSubgraphCommands) {
-                commands.push(
-                    { command: SAVE_SUBGRAPH_COMMAND, title: "Save Subgraph", icon: Icons.DeviceFloppy },
-                    { command: SWITCH_TO_MAIN_GRAPH_COMMAND, title: "Back to Main Graph", icon: Icons.ArrowLeft },
-                );
-            }
-
-            commands.push(...viewModel.value.settings.toolbar.additionalSubgraphCommands);
-
-            return commands;
-        });
-
-        return { isSubgraph, commands, subgraphCommands };
-    },
-});
+const { viewModel } = useViewModel();
+const isSubgraph = computed(() => viewModel.value.displayedGraph !== viewModel.value.editor.graph);
+const commands = computed(() => viewModel.value.settings.toolbar.commands);
+const subgraphCommands = computed(() => viewModel.value.settings.toolbar.subgraphCommands);
 </script>

--- a/packages/renderer-vue/src/toolbar/Toolbar.vue
+++ b/packages/renderer-vue/src/toolbar/Toolbar.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from "vue";
+import { computed, defineComponent, Component } from "vue";
 import { useViewModel } from "../utility";
 import {
     COPY_COMMAND,
@@ -32,6 +32,12 @@ import {
 import * as Icons from "../icons";
 import ToolbarButton from "./ToolbarButton.vue";
 
+interface ToolbarCommand {
+    command: string;
+    title: string;
+    icon?: Component;
+}
+
 export default defineComponent({
     components: { ToolbarButton },
     setup() {
@@ -39,21 +45,44 @@ export default defineComponent({
 
         const isSubgraph = computed(() => viewModel.value.displayedGraph !== viewModel.value.editor.graph);
 
-        const commands = [
-            { command: COPY_COMMAND, title: "Copy", icon: Icons.Copy },
-            { command: PASTE_COMMAND, title: "Paste", icon: Icons.Clipboard },
-            { command: DELETE_NODES_COMMAND, title: "Delete selected nodes", icon: Icons.Trash },
-            { command: UNDO_COMMAND, title: "Undo", icon: Icons.ArrowBackUp },
-            { command: REDO_COMMAND, title: "Redo", icon: Icons.ArrowForwardUp },
-            { command: ZOOM_TO_FIT_GRAPH_COMMAND, title: "Zoom to Fit", icon: Icons.ZoomScan },
-            { command: START_SELECTION_BOX_COMMAND, title: "Box Select", icon: Icons.SelectAll },
-            { command: CREATE_SUBGRAPH_COMMAND, title: "Create Subgraph", icon: Icons.Hierarchy2 },
-        ];
+        const commands = computed(() => {
+            const commands: ToolbarCommand[] = [];
 
-        const subgraphCommands = [
-            { command: SAVE_SUBGRAPH_COMMAND, title: "Save Subgraph", icon: Icons.DeviceFloppy },
-            { command: SWITCH_TO_MAIN_GRAPH_COMMAND, title: "Back to Main Graph", icon: Icons.ArrowLeft },
-        ];
+            if (viewModel.value.settings.toolbar.useDefaultCommands) {
+                commands.push(
+                    { command: COPY_COMMAND, title: "Copy", icon: Icons.Copy },
+                    { command: PASTE_COMMAND, title: "Paste", icon: Icons.Clipboard },
+                    { command: DELETE_NODES_COMMAND, title: "Delete selected nodes", icon: Icons.Trash },
+                    { command: UNDO_COMMAND, title: "Undo", icon: Icons.ArrowBackUp },
+                    { command: REDO_COMMAND, title: "Redo", icon: Icons.ArrowForwardUp },
+                    { command: ZOOM_TO_FIT_GRAPH_COMMAND, title: "Zoom to Fit", icon: Icons.ZoomScan },
+                    { command: START_SELECTION_BOX_COMMAND, title: "Box Select", icon: Icons.SelectAll },
+                );
+            }
+
+            commands.push(...viewModel.value.settings.toolbar.additionalCommands);
+
+            if (viewModel.value.settings.toolbar.useDefaultCommands) {
+                commands.push({ command: CREATE_SUBGRAPH_COMMAND, title: "Create Subgraph", icon: Icons.Hierarchy2 });
+            }
+
+            return commands;
+        });
+
+        const subgraphCommands = computed(() => {
+            const commands: ToolbarCommand[] = [];
+
+            if (viewModel.value.settings.toolbar.useDefaultSubgraphCommands) {
+                commands.push(
+                    { command: SAVE_SUBGRAPH_COMMAND, title: "Save Subgraph", icon: Icons.DeviceFloppy },
+                    { command: SWITCH_TO_MAIN_GRAPH_COMMAND, title: "Back to Main Graph", icon: Icons.ArrowLeft },
+                );
+            }
+
+            commands.push(...viewModel.value.settings.toolbar.additionalSubgraphCommands);
+
+            return commands;
+        });
 
         return { isSubgraph, commands, subgraphCommands };
     },

--- a/packages/renderer-vue/src/toolbar/index.ts
+++ b/packages/renderer-vue/src/toolbar/index.ts
@@ -1,0 +1,1 @@
+export * from "./toolbarCommands";

--- a/packages/renderer-vue/src/toolbar/toolbarCommands.ts
+++ b/packages/renderer-vue/src/toolbar/toolbarCommands.ts
@@ -1,0 +1,38 @@
+import { Component } from "vue";
+import {
+    COPY_COMMAND,
+    PASTE_COMMAND,
+    UNDO_COMMAND,
+    REDO_COMMAND,
+    CREATE_SUBGRAPH_COMMAND,
+    SAVE_SUBGRAPH_COMMAND,
+    START_SELECTION_BOX_COMMAND,
+    DELETE_NODES_COMMAND,
+    SWITCH_TO_MAIN_GRAPH_COMMAND,
+    ZOOM_TO_FIT_GRAPH_COMMAND,
+} from "../commandList";
+import * as Icons from "../icons";
+
+export interface ToolbarCommand {
+    command: string;
+    title: string;
+    icon?: Component;
+}
+
+export const TOOLBAR_COMMANDS: Record<string, ToolbarCommand> = {
+    COPY: { command: COPY_COMMAND, title: "Copy", icon: Icons.Copy },
+    PASTE: { command: PASTE_COMMAND, title: "Paste", icon: Icons.Clipboard },
+    DELETE_NODES: { command: DELETE_NODES_COMMAND, title: "Delete selected nodes", icon: Icons.Trash },
+    UNDO: { command: UNDO_COMMAND, title: "Undo", icon: Icons.ArrowBackUp },
+    REDO: { command: REDO_COMMAND, title: "Redo", icon: Icons.ArrowForwardUp },
+    ZOOM_TO_FIT_GRAPH: { command: ZOOM_TO_FIT_GRAPH_COMMAND, title: "Zoom to Fit", icon: Icons.ZoomScan },
+    START_SELECTION_BOX: { command: START_SELECTION_BOX_COMMAND, title: "Box Select", icon: Icons.SelectAll },
+    CREATE_SUBGRAPH: { command: CREATE_SUBGRAPH_COMMAND, title: "Create Subgraph", icon: Icons.Hierarchy2 },
+};
+export const DEFAULT_TOOLBAR_COMMANDS: ToolbarCommand[] = Object.values(TOOLBAR_COMMANDS);
+
+export const TOOLBAR_SUBGRAPH_COMMANDS: Record<string, ToolbarCommand> = {
+    SAVE_SUBGRAPH: { command: SAVE_SUBGRAPH_COMMAND, title: "Save Subgraph", icon: Icons.DeviceFloppy },
+    SWITCH_TO_MAIN_GRAPH: { command: SWITCH_TO_MAIN_GRAPH_COMMAND, title: "Back to Main Graph", icon: Icons.ArrowLeft },
+};
+export const DEFAULT_TOOLBAR_SUBGRAPH_COMMANDS: ToolbarCommand[] = Object.values(TOOLBAR_SUBGRAPH_COMMANDS);


### PR DESCRIPTION
This PR adds settings that make is possible to customize the toolbar commands/buttons. Additional toolbar commands can be specified and the default toolbar commands can be hidden.

Closes #307.