### PR TITLE
Fix applyResult behavior for issue #418

### DIFF
--- a/packages/engine/src/applyResult.ts
+++ b/packages/engine/src/applyResult.ts
@@ -1,15 +1,23 @@
-import { AbstractNode, Editor, CalculationResult } from "@baklavajs/core";
+import { AbstractNode, Editor, CalculationResult, IConnection } from "@baklavajs/core";
+
+export interface ApplyResultOptions {
+    transferData?: (value: any, connection: IConnection) => any;
+}
 
 /**
- * Apply the calculation result values to the output interfaces in the graph
+ * Apply the calculation result values to the output interfaces in the graph and
+ * propagate updated output values to connected input interfaces.
  * @param result Calculation result
  * @param editor Editor instance
+ * @param options Optional hooks for applying connection data transformations
  */
-export function applyResult(result: CalculationResult, editor: Editor): void {
+export function applyResult(result: CalculationResult, editor: Editor, options?: ApplyResultOptions): void {
     const nodeMap: Map<string, AbstractNode> = new Map();
     editor.graphs.forEach((g) => {
         g.nodes.forEach((n) => nodeMap.set(n.id, n));
     });
+
+    const outputValues = new Map<string, any>();
 
     result.forEach((intfValues, nodeId) => {
         const node = nodeMap.get(nodeId);
@@ -24,6 +32,35 @@ export function applyResult(result: CalculationResult, editor: Editor): void {
             }
 
             intf.value = value;
+            outputValues.set(intf.id, value);
+        });
+    });
+
+    editor.graphs.forEach((g) => {
+        const updatedMultiInputs = new Set<string>();
+        const getTransferredValue = (connection: IConnection) => {
+            const value = outputValues.get(connection.from.id) ?? connection.from.value;
+            return options?.transferData?.(value, connection) ?? value;
+        };
+
+        g.connections.forEach((c) => {
+            if (!outputValues.has(c.from.id)) {
+                return;
+            }
+
+            if (c.to.allowMultipleConnections) {
+                updatedMultiInputs.add(c.to.id);
+            } else {
+                c.to.value = getTransferredValue(c);
+            }
+        });
+
+        updatedMultiInputs.forEach((inputId) => {
+            const connections = g.connections.filter((c) => c.to.id === inputId);
+            const input = connections[0]?.to;
+            if (input) {
+                input.value = connections.map((c) => getTransferredValue(c));
+            }
         });
     });
 }

--- a/packages/engine/test/applyResult.spec.ts
+++ b/packages/engine/test/applyResult.spec.ts
@@ -45,6 +45,70 @@ describe("applyResult", () => {
         expect(n3.outputs.d.value).toEqual(0);
     });
 
+    it("updates connected input interface values", () => {
+        const e = new Editor();
+        const n1 = new TestNode();
+        const n2 = new TestNode();
+        e.graph.addNode(n1);
+        e.graph.addNode(n2);
+        e.graph.addConnection(n1.outputs.c, n2.inputs.a);
+
+        applyResult(new Map([[n1.id, new Map([["c", 10]])]]), e);
+
+        expect(n1.outputs.c.value).toEqual(10);
+        expect(n2.inputs.a.value).toEqual(10);
+    });
+
+    it("applies connection data transformations to connected input interface values", () => {
+        const e = new Editor();
+        const n1 = new TestNode();
+        const n2 = new TestNode();
+        e.graph.addNode(n1);
+        e.graph.addNode(n2);
+        e.graph.addConnection(n1.outputs.c, n2.inputs.a);
+
+        applyResult(new Map([[n1.id, new Map([["c", 10]])]]), e, {
+            transferData: (value) => String(value),
+        });
+
+        expect(n2.inputs.a.value).toEqual("10");
+    });
+
+    it("doesn't update disconnected input interface values", () => {
+        const e = new Editor();
+        const n1 = new TestNode();
+        const n2 = new TestNode();
+        e.graph.addNode(n1);
+        e.graph.addNode(n2);
+
+        applyResult(new Map([[n1.id, new Map([["c", 10]])]]), e);
+
+        expect(n2.inputs.a.value).toEqual(1);
+    });
+
+    it("updates connected multi-input interface values", () => {
+        const e = new Editor();
+        const n1 = new TestNode();
+        const n2 = new TestNode();
+        const n3 = new TestNode();
+        e.graph.addNode(n1);
+        e.graph.addNode(n2);
+        e.graph.addNode(n3);
+        n3.inputs.a.allowMultipleConnections = true;
+        e.graph.addConnection(n1.outputs.c, n3.inputs.a);
+        e.graph.addConnection(n2.outputs.c, n3.inputs.a);
+
+        applyResult(
+            new Map([
+                [n1.id, new Map([["c", 10]])],
+                [n2.id, new Map([["c", 20]])],
+            ]),
+            e,
+        );
+
+        expect(n3.inputs.a.value).toEqual([10, 20]);
+    });
+
     it("doesn't fail on non-existing ids", () => {
         const e = new Editor();
         const n1 = new TestNode();

--- a/packages/renderer-vue/playground/App.vue
+++ b/packages/renderer-vue/playground/App.vue
@@ -195,7 +195,9 @@ const token = Symbol("token");
 const engine = new DependencyEngine(dep.editor);
 engine.events.afterRun.subscribe(token, (r) => {
     engine.pause();
-    applyResult(r, dep.editor);
+    applyResult(r, dep.editor, {
+        transferData: (value, connection) => engine.hooks.transferData.execute(value, connection),
+    });
     engine.resume();
     console.log(r);
 });
@@ -211,7 +213,9 @@ const forwardToken = Symbol("forwardToken");
 const forwardEngine = new ForwardEngine(fwd.editor);
 forwardEngine.events.afterRun.subscribe(forwardToken, (r) => {
     forwardEngine.pause();
-    applyResult(r, fwd.editor);
+    applyResult(r, fwd.editor, {
+        transferData: (value, connection) => forwardEngine.hooks.transferData.execute(value, connection),
+    });
     forwardEngine.resume();
     console.log("Forward Engine result:", r);
 });


### PR DESCRIPTION
Fixes #418.

This updates `applyResult` so calculated output values are also propagated to connected input interfaces. This keeps rendered input state, including tooltips, in sync after engine runs.

## Changes

- Propagate updated output values through graph connections after applying calculation results.
- Add optional `transferData` support so connected input values use the same connection transformation path as engine calculation.
- Rebuild multi-input interface values from all incoming connections when one of the sources updates.
- Preserve disconnected input values.
- Update the Vue playground engine hooks to pass `transferData` into `applyResult`.
- Add focused tests for connected inputs, transformed values, disconnected inputs, and multi-input propagation.

## Testing

- Added coverage in `packages/engine/test/applyResult.spec.ts`.
- Reviewed commit `cc09e42 fix: issue #418`; I did not rerun the test suite in this turn.